### PR TITLE
Implement editable sticky notes with title and body, and add localStorage support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,21 +28,7 @@
 }
 
 
-.note {
-    background-color: #fff9a6;
-    padding: 10px;
-    margin: 10px;
-    width: 150px;
-    height: 150px;
-    border-radius: 5px;
-    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
-    overflow: auto;
-}
 
-.note:focus {
-    outline: none;
-    box-shadow: 0 0 5px rgba(0, 0, 255, 0.5);
-}
 
 #notes-container {
     display: flex;
@@ -77,4 +63,30 @@ body {
     margin: 0;
     padding: 0;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+
+.note {
+    background-color: #fff9a6;
+    border-radius: 5px;
+    padding: 10px;
+    margin: 10px;
+    min-width: 200px;
+    height: 200px;
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
+}
+
+.note-title {
+    font-weight: bold;
+    font-size: 18px;
+    border-bottom: 1px solid rgb(36, 183, 252);
+    padding-bottom: 5px;
+    margin-bottom: 8px;
+}
+
+.note-body {
+    font-size: 14px;
+    height: 150px;
+    overflow-y: auto;
+
 }

--- a/js/index.js
+++ b/js/index.js
@@ -12,9 +12,26 @@ clearAll.addEventListener("click", () => {
 
 // Creates a new editable sticky note and appends it to the notes container
 function createStickyNote() {
+    // Create the main note container
     const note = document.createElement("div");
     note.classList.add("note");
-    note.contentEditable = true;
-    note.textContent = "New note";
+
+    // Create title element
+    const noteTitle = document.createElement("div");
+    noteTitle.classList.add("note-title");
+    noteTitle.contentEditable = true;
+    noteTitle.textContent = "Note Title";
+
+    // Create body element
+    const noteBody = document.createElement("div");
+    noteBody.classList.add("note-body");
+    noteBody.contentEditable = true;
+    noteBody.textContent = "Type your note here...";
+
+    // Append title and body to the note
+    note.appendChild(noteTitle);
+    note.appendChild(noteBody);
+
+    // Append the note to the container
     document.getElementById("notes-container").appendChild(note);
 }

--- a/js/index.js
+++ b/js/index.js
@@ -3,15 +3,51 @@ const addNewNote = document.getElementById("addNewnote");
 const clearAll = document.getElementById("clearAll");
 
 // Add event listener to create a new sticky note when button is clicked
-addNewNote.addEventListener("click", createStickyNote);
+addNewNote.addEventListener("click", () => createStickyNote());
 
 // Add event listener to clear all notes from the container
 clearAll.addEventListener("click", () => {
     document.getElementById("notes-container").innerHTML = "";
+    // Clear localStorage
+    localStorage.removeItem('stickyNotes');
 });
 
+// Load saved notes when the page loads
+document.addEventListener('DOMContentLoaded', loadNotes);
+
+// Function to save notes to localStorage
+function saveNotes() {
+    const notesContainer = document.getElementById("notes-container");
+    const notes = [];
+
+    // Collect all notes
+    const noteElements = notesContainer.querySelectorAll('.note');
+    noteElements.forEach(noteElement => {
+        const title = noteElement.querySelector('.note-title').innerHTML;
+        const body = noteElement.querySelector('.note-body').innerHTML;
+        notes.push({ title, body });
+    });
+
+    // Save to localStorage
+    localStorage.setItem('stickyNotes', JSON.stringify(notes));
+}
+
+// Function to load notes from localStorage
+function loadNotes() {
+    const savedNotes = localStorage.getItem('stickyNotes');
+
+    if (savedNotes) {
+        const notes = JSON.parse(savedNotes);
+
+        // Create each saved note
+        notes.forEach(note => {
+            createStickyNote(note.title, note.body);
+        });
+    }
+}
+
 // Creates a new editable sticky note and appends it to the notes container
-function createStickyNote() {
+function createStickyNote(title = "Note Title", body = "Type your note here...") {
     // Create the main note container
     const note = document.createElement("div");
     note.classList.add("note");
@@ -20,13 +56,17 @@ function createStickyNote() {
     const noteTitle = document.createElement("div");
     noteTitle.classList.add("note-title");
     noteTitle.contentEditable = true;
-    noteTitle.textContent = "Note Title";
+    noteTitle.innerHTML = title;
 
     // Create body element
     const noteBody = document.createElement("div");
     noteBody.classList.add("note-body");
     noteBody.contentEditable = true;
-    noteBody.textContent = "Type your note here...";
+    noteBody.innerHTML = body;
+
+    // Add event listeners to save on content changes
+    noteTitle.addEventListener('blur', saveNotes);
+    noteBody.addEventListener('blur', saveNotes);
 
     // Append title and body to the note
     note.appendChild(noteTitle);
@@ -34,4 +74,7 @@ function createStickyNote() {
 
     // Append the note to the container
     document.getElementById("notes-container").appendChild(note);
+
+    // Save to localStorage
+    saveNotes();
 }


### PR DESCRIPTION
### What has changed?
- Sticky notes now have two editable sections: a title and a body
- Notes are saved to localStorage with both title and body content
- Notes are automatically loaded from localStorage on page load
- "Clear All" button now clears both the UI and the stored notes
- Updated CSS to style note titles and bodies separately for a cleaner layout

### Why?
- To enable persistent sticky notes across page reloads
- To enhance user experience with a clearer note structure and better visual separation
- To lay the groundwork for future features like note deletion, drag-and-drop, and color customization

### Affected files:
- `css/style.css`
- `js/index.js`