### PR TITLE
Add max width to title and body

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -72,6 +72,7 @@ body {
     padding: 10px;
     margin: 10px;
     min-width: 200px;
+    max-width: 200px;
     height: 200px;
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
     position: relative;
@@ -90,6 +91,10 @@ body {
     border-bottom: 1px solid rgb(36, 183, 252);
     padding-bottom: 5px;
     flex-grow: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: calc(100% - 30px);
 }
 
 .delete-note {
@@ -124,5 +129,8 @@ body {
     font-size: 14px;
     height: 150px;
     overflow-y: auto;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
 
 }


### PR DESCRIPTION
## What has changed?
- Updated note layout to handle long text more gracefully
- Enabled text wrapping for the note body to prevent overflow
- Limited the note title  to a single line
- Break text into new line when text width is to high
- Improved overall readability and consistency in note presentation

## Why?
- To prevent layout issues when users enter long text
- To maintain a clean and structured appearance for all notes
- To enhance user experience by ensuring notes remain visually compact

## Affected files:
- `css/style.css`