### PR TITLE
Fixed issue with date selector not showing up when editing a deadline

### DIFF
--- a/js/noteCreation.js
+++ b/js/noteCreation.js
@@ -335,10 +335,9 @@ function showDeadlineDialog(note) {
 
     // Replace your native date input:
     const dateInput = document.createElement('input');
-    dateInput.type        = 'text';
+    dateInput.type        = 'date';
     dateInput.id          = 'deadline-date-input';
     dateInput.className   = 'modal-input';
-    dateInput.placeholder = 'dd/mm-yyyy';
 
 
    // If there's already a deadline, set the input value


### PR DESCRIPTION
Date selector with mouse now shows up when editing an existing deadline.