### PR TITLE
Fix Missing Deadline Input in Category Dropdown Note Creation

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -26,7 +26,7 @@ clearAll.addEventListener("click", () => {
 });
 
 // Update the showAddNoteDialog function to include deadline input
-function showAddNoteDialog() {
+function showAddNoteDialog(preselectedCategory = null) {
     // Create modal dialog
     const modal = document.createElement('div');
     modal.classList.add('modal');
@@ -68,6 +68,10 @@ function showAddNoteDialog() {
         const option = document.createElement('option');
         option.value = category;
         option.textContent = category;
+        // If a preselected category is provided, select it
+        if (preselectedCategory && category === preselectedCategory) {
+            option.selected = true;
+        }
         categorySelect.appendChild(option);
     });
 
@@ -101,7 +105,7 @@ function showAddNoteDialog() {
     createButton.addEventListener('click', () => {
         const selectedCategory = categorySelect.value;
         const noteTitle = titleInput.value.trim() || 'Title'; // Use entered title or default to 'Title'
-        
+
         // Format deadline if provided (dd/mm-yyyy)
         let formattedDeadline = '';
         if (deadlineInput.value) {
@@ -111,7 +115,7 @@ function showAddNoteDialog() {
             const year = date.getFullYear();
             formattedDeadline = `${day}/${month}-${year}`;
         }
-        
+
         createStickyNote(noteTitle, "Content", "#fff9a6", selectedCategory, formattedDeadline);
         document.body.removeChild(modal);
     });
@@ -373,7 +377,8 @@ function createCategorySection(categoryName) {
     newNoteOption.classList.add('dropdown-item', 'new-note-option');
     newNoteOption.textContent = 'Add new note';
     newNoteOption.addEventListener('click', () => {
-        createStickyNote("Title", "Content", "#fff9a6", categoryName);
+        // Replace direct sticky note creation with the dialog
+        showAddNoteDialog(categoryName);
         dropdownContent.classList.remove('show');
     });
     dropdownContent.appendChild(newNoteOption);


### PR DESCRIPTION
## Description
This PR addresses an inconsistency in the note creation process. Previously, when creating a note via the category dropdown menu, users were not presented with the deadline input field. However, this field was correctly shown when using the main "Create New Note" button. This inconsistency created a confusing user experience and limited functionality when using the category dropdown.

## What Changed
- Modified the "Add new note" option in category dropdowns to use the same dialog as the main "Create New Note" button
- Updated the `showAddNoteDialog()` function to accept an optional `preselectedCategory` parameter
- Ensured that when creating a note from a category dropdown, the category is pre-selected in the dialog

## Why This Change
This change ensures a consistent user experience by:
- Providing the same set of options (including deadline setting) regardless of which entry point the user chooses to create a note
- Maintaining the context of which category the user is working with when creating from a dropdown
- Reducing code duplication by reusing the existing note creation dialog

## Implementation Details
The implementation passes the current category name to the `showAddNoteDialog()` function when a user clicks "Add new note" in a category dropdown. The dialog then pre-selects this category in the dropdown menu while providing all other fields, including the deadline input.

Prior to this change, notes created from category dropdowns would skip the dialog entirely and not offer deadline functionality.

## Files Changed
- `js/index.js`: Modified to reuse the existing dialog with pre-selected category
