### PR TITLE
Add Drag-and-Drop Support for Sticky Notes

### DIFF
--- a/css/categories.css
+++ b/css/categories.css
@@ -23,6 +23,16 @@
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
+    padding: 8px;
+    /* Added padding for consistency */
+    border: 2px dashed transparent;
+    /* Added transparent border to reserve space */
+    border-radius: 5px;
+    /* Optional: if you want rounded corners for the notes area */
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+    /* Smooth transition for highlighting */
+    min-height: 50px;
+    /* Ensure drop target has some height even if empty */
 }
 
 /* Modal dialog styles */

--- a/css/notes.css
+++ b/css/notes.css
@@ -172,3 +172,27 @@ body.dark-mode .deadline-option {
     justify-content: space-between;
     margin-top: 20px;
 }
+
+/* Drag and drop styles */
+.note.dragging {
+    opacity: 0.5;
+    /* Make the dragged note semi-transparent */
+    cursor: grabbing;
+}
+
+.category-notes.drag-over {
+    background-color: rgba(36, 183, 252, 0.1);
+    /* Highlight background */
+    border-color: rgba(36, 183, 252, 0.7);
+    /* Highlight border */
+    /* padding: 10px; */
+    /* Removed: padding is now in base .category-notes style */
+    /* border-radius: 5px; */
+    /* Removed: border-radius is now in base .category-notes style */
+}
+
+/* Dark mode support for drag-over */
+body.dark-mode .category-notes.drag-over {
+    background-color: rgba(88, 182, 230, 0.2);
+    border-color: rgba(88, 182, 230, 0.7);
+}

--- a/js/dragAndDrop.js
+++ b/js/dragAndDrop.js
@@ -1,0 +1,114 @@
+import { saveNotes } from './noteStorage.js';
+
+let draggedNote = null; // Stores the actual DOM element being dragged
+
+function handleDragStart(e) {
+    draggedNote = this; // 'this' is the note element being dragged
+    // It's good practice to set some data, e.g., the note's ID
+    e.dataTransfer.setData('text/plain', this.id);
+    e.dataTransfer.effectAllowed = 'move';
+
+    // Add 'dragging' class with a slight delay
+    // This allows the browser to capture the drag image before the style changes
+    setTimeout(() => {
+        if (draggedNote) { // Check if draggedNote still exists (it should)
+            draggedNote.classList.add('dragging');
+        }
+    }, 0);
+}
+
+function handleDragEnd() {
+    // 'this' is the note element that was dragged
+    if (this.classList.contains('dragging')) {
+        this.classList.remove('dragging');
+    }
+    // Clean up any .drag-over classes on category containers
+    document.querySelectorAll('.category-notes.drag-over').forEach(container => {
+        container.classList.remove('drag-over');
+    });
+    draggedNote = null; // Clear the reference to the dragged note
+}
+
+function handleDragOver(e) {
+    e.preventDefault(); // Necessary to allow a drop
+    e.dataTransfer.dropEffect = 'move'; // Visual cue to the user
+
+    // 'this' is the .category-notes container being dragged over
+    // Add highlight if a note is being dragged and it's not over its current parent container
+    if (draggedNote && draggedNote.parentElement !== this) {
+        this.classList.add('drag-over');
+    }
+}
+
+function handleDragEnter(e) {
+    // 'this' is the .category-notes container
+    // Add highlight if the cursor enters the container itself (not a child element within it)
+    // and a valid note is being dragged from another container.
+    if (e.target === this && draggedNote && draggedNote.parentElement !== this) {
+        this.classList.add('drag-over');
+    }
+}
+
+function handleDragLeave(e) {
+    // 'this' is the .category-notes container
+    // Remove highlight if the cursor leaves the container itself.
+    // Check e.relatedTarget to ensure the cursor is not moving to a child inside the container.
+    if (e.target === this && (!e.relatedTarget || !this.contains(e.relatedTarget))) {
+        this.classList.remove('drag-over');
+    }
+}
+
+function handleDrop(e) {
+    e.preventDefault(); // Prevent default browser action
+    // 'this' is the .category-notes container where the note is dropped
+    this.classList.remove('drag-over'); // Remove highlight
+
+    // Proceed if a valid note was being dragged and it's not dropped into its original container
+    if (draggedNote && draggedNote.parentElement !== this) {
+        const categorySection = this.closest('.category-section');
+        if (categorySection) {
+            const targetCategoryName = categorySection.dataset.category;
+            this.appendChild(draggedNote); // Move the actual DOM element
+            draggedNote.dataset.category = targetCategoryName; // Update the note's category
+            saveNotes(); // Save all notes with updated categories
+        } else {
+            console.error('Could not determine target category for the dropped note.');
+        }
+    }
+    // draggedNote is cleared in handleDragEnd
+}
+
+export function initializeDragAndDrop() {
+    // Initialize notes to be draggable
+    const notes = document.querySelectorAll('.note');
+    notes.forEach(note => {
+        if (!note.id) { // Ensure each note has a unique ID for robust tracking
+            note.id = `note-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        }
+        note.setAttribute('draggable', 'true');
+
+        // Remove existing listeners before adding new ones to prevent duplicates if this function is called multiple times
+        note.removeEventListener('dragstart', handleDragStart);
+        note.addEventListener('dragstart', handleDragStart);
+
+        note.removeEventListener('dragend', handleDragEnd);
+        note.addEventListener('dragend', handleDragEnd);
+    });
+
+    // Initialize category notes containers to be droppable
+    const categoryNotesContainers = document.querySelectorAll('.category-notes');
+    categoryNotesContainers.forEach(container => {
+        // Remove existing listeners
+        container.removeEventListener('dragover', handleDragOver);
+        container.addEventListener('dragover', handleDragOver);
+
+        container.removeEventListener('dragenter', handleDragEnter);
+        container.addEventListener('dragenter', handleDragEnter);
+
+        container.removeEventListener('dragleave', handleDragLeave);
+        container.addEventListener('dragleave', handleDragLeave);
+
+        container.removeEventListener('drop', handleDrop);
+        container.addEventListener('drop', handleDrop);
+    });
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,7 @@
 import { saveNotes, loadNotes, sortNotesByDeadline } from './noteStorage.js';
 import { createStickyNote } from './noteCreation.js';
 import { getCategories, addCategory, getCategoryColor, setCategoryColor } from './categoryManagement.js';
+import { initializeDragAndDrop } from './dragAndDrop.js'; // Import the new module
 
 // Get reference to the "Add Note" and "Clear All" buttons
 const addNewNote = document.getElementById("addNewnote");
@@ -117,6 +118,8 @@ function showAddNoteDialog(preselectedCategory = null) {
         }
 
         createStickyNote(noteTitle, "Content", "#fff9a6", selectedCategory, formattedDeadline);
+        saveNotes(); // Save the new note to localStorage
+        initializeDragAndDrop(); // Make the new note draggable and update drop targets
         document.body.removeChild(modal);
     });
 
@@ -258,7 +261,7 @@ function showAddCategoryDialog() {
             if (categoryHeader) {
                 categoryHeader.style.backgroundColor = selectedColor;
             }
-
+            initializeDragAndDrop(); // Ensure new category container is a drop target
             document.body.removeChild(modal);
         } else {
             alert("Category already exists!");
@@ -481,6 +484,7 @@ function handleCategoryRemoval(categoryName, sectionElement) {
 
     // Save notes with updated categories
     saveNotes();
+    initializeDragAndDrop(); // Re-initialize in case notes were moved or categories changed
 }
 
 // Function to toggle dark mode
@@ -516,7 +520,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Load saved notes
-    loadNotes();
+    loadNotes(); // This calls createStickyNote, which now assigns IDs
+
+    initializeDragAndDrop(); // Initialize for all loaded notes and category containers
 
     // Check if dark mode was previously enabled
     checkDarkModePreference();

--- a/js/noteCreation.js
+++ b/js/noteCreation.js
@@ -6,6 +6,7 @@ export function createStickyNote(title = "Title", body = "Content", color = "#ff
     // Create the main note container
     const note = document.createElement("div");
     note.classList.add("note");
+    note.id = `note-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`; // Assign unique ID
     note.style.backgroundColor = color;
     note.dataset.category = category; // Store category in data attribute
     note.dataset.deadline = deadline; // Store deadline in data attribute
@@ -335,24 +336,24 @@ function showDeadlineDialog(note) {
 
     // Replace your native date input:
     const dateInput = document.createElement('input');
-    dateInput.type        = 'date';
-    dateInput.id          = 'deadline-date-input';
-    dateInput.className   = 'modal-input';
+    dateInput.type = 'date';
+    dateInput.id = 'deadline-date-input';
+    dateInput.className = 'modal-input';
 
 
-   // If there's already a deadline, set the input value
+    // If there's already a deadline, set the input value
     if (note.dataset.deadline) {
         const [day, month, year] = note.dataset.deadline.split(/[-\/]/);
         // Convert to the correct input format (yyyy-mm-dd)
         dateInput.value = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
     }
 
-    
+
     dateInput.addEventListener("change", () => {
         const [year, month, day] = dateInput.value.split("-");
         note.dataset.deadline = `${day}/${month}-${year}`;
     });
-    
+
     modalContent.appendChild(dateInput);
 
     // Create buttons


### PR DESCRIPTION
## Description

This pull request introduces drag-and-drop functionality to the sticky notes application. Users can now move notes between categories by simply dragging and dropping them. The implementation ensures a smooth experience by moving the actual DOM elements, preserving all attached event listeners and editable states.

## Why

Currently, the application lacks an intuitive way to reorganize notes across categories. Adding drag-and-drop provides the following benefits:

- Improves usability and interaction.
- Makes note organization more flexible and user-friendly.
- Maintains existing interactivity (e.g., dropdowns, editable fields) by avoiding DOM reconstruction.

## Details

- **New file: `js/dragAndDrop.js`**
  - Contains the core logic for enabling drag-and-drop.
  - Implements `initializeDragAndDrop()` to set up draggable notes and droppable category containers.

- **Modified: `js/noteCreation.js`**
  - `createStickyNote()` now assigns a unique ID to each note.
  - These IDs are essential for tracking and managing notes during drag-and-drop operations.

- **Modified: `js/index.js`**
  - Imports and calls `initializeDragAndDrop()`:
    - After loading notes on initial page load.
    - After a new note is created.
    - After a new category is added.
  - Calls `saveNotes()` after dialog-based note creation to persist data, since `createStickyNote()` only updates the DOM.

## Files Changed

- `js/dragAndDrop.js` – new file
- `js/noteCreation.js` – updated to assign unique note IDs
- `js/index.js` – integrated drag-and-drop and added necessary calls to `initializeDragAndDrop()` and `saveNotes()`
