### PR TITLE
New dark mode toggle

### DIFF
--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -23,12 +23,13 @@
     transform: scale(1.1);
 }
 
+/* Remove old icon styles as they are no longer in the HTML */
+/*
 .moon-icon,
 .sun-icon {
     font-size: 20px;
 }
 
-/* Show moon in light mode, sun in dark mode */
 .moon-icon {
     display: block;
 }
@@ -44,6 +45,7 @@ body.dark-mode .moon-icon {
 body.dark-mode .sun-icon {
     display: block;
 }
+*/
 
 /* Dark mode styles */
 body.dark-mode {
@@ -84,7 +86,75 @@ body.dark-mode .note-title {
     border-bottom: 1px solid #58b6e6;
 }
 
-body.dark-mode .dark-mode-toggle {
-    background-color: #333;
-    border-color: #555;
+/* Updated styles for the new SVG toggle button */
+#darkModeToggle {
+    background: transparent;
+    /* Make button background transparent */
+    border: none;
+    /* Remove border */
+    padding: 0;
+    width: 40px;
+    /* Keep original click area size */
+    height: 40px;
+    /* border-radius: 50%; */
+    /* Optional: remove if button is transparent */
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: rgb(36, 183, 252);
+    /* Sun color: Orange/Yellow */
+    transition: color 0.4s ease, transform 0.4s ease;
+}
+
+#darkModeToggle:hover {
+    /* transform: scale(1.1); */
+    /* Already applied by .dark-mode-toggle */
+    /* color: #e67e22; */
+    /* Darker sun color on hover */
+}
+
+#darkModeToggle svg.theme-toggle__expand {
+    width: 26px;
+    /* Adjust SVG size as desired */
+    height: 26px;
+    transition: transform 0.5s cubic-bezier(.5, -.75, .25, 1.75);
+    /* Rotation with a bit of bounce */
+}
+
+/* Styles for the rays part of the SVG (the complex path within the <g> element) */
+#darkModeToggle svg.theme-toggle__expand g>path {
+    transform-origin: 16px 16px;
+    /* Center of the SVG's viewBox (0 0 32 32) */
+    transform: scale(1);
+    opacity: 1;
+    transition: transform 0.4s ease-out 0.1s, opacity 0.3s ease-out 0.1s;
+    /* Delay transition slightly */
+}
+
+
+/* Dark mode specific styles for the toggle button */
+body.dark-mode #darkModeToggle {
+    /* background-color: #333; */
+    /* Keep if a background is desired for the button */
+    /* border-color: #555; */
+    /* Keep if a border is desired */
+    color: rgb(36, 183, 252);
+    /* Moon color: Light Blue */
+}
+
+/* body.dark-mode #darkModeToggle:hover {
+  color: #3498db; 
+} */
+
+body.dark-mode #darkModeToggle svg.theme-toggle__expand {
+    transform: rotate(180deg);
+}
+
+body.dark-mode #darkModeToggle svg.theme-toggle__expand g>path {
+    /* Hide rays in dark mode */
+    transform: scale(0.5);
+    /* Scale down rays */
+    opacity: 0;
+    /* Make rays transparent */
 }

--- a/index.html
+++ b/index.html
@@ -17,9 +17,18 @@
 
 <body>
     <div id="dark-mode-container">
-        <button id="darkModeToggle" class="dark-mode-toggle" aria-label="Toggle dark mode">
-            <span class="moon-icon">🌙</span>
-            <span class="sun-icon">☀️</span>
+        <button id="darkModeToggle" class="theme-toggle" type="button" title="Toggle theme" aria-label="Toggle theme">
+            <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="1em" height="1em" fill="currentColor"
+                class="theme-toggle__expand" viewBox="0 0 32 32">
+                <clipPath id="theme-toggle__expand__cutout">
+                    <path d="M0-11h25a1 1 0 0017 13v30H0Z" />
+                </clipPath>
+                <g clip-path="url(#theme-toggle__expand__cutout)">
+                    <circle cx="16" cy="16" r="8.4" />
+                    <path
+                        d="M18.3 3.2c0 1.3-1 2.3-2.3 2.3s-2.3-1-2.3-2.3S14.7.9 16 .9s2.3 1 2.3 2.3zm-4.6 25.6c0-1.3 1-2.3 2.3-2.3s2.3 1 2.3 2.3-1 2.3-2.3 2.3-2.3-1-2.3-2.3zm15.1-10.5c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zM3.2 13.7c1.3 0 2.3 1 2.3 2.3s-1 2.3-2.3 2.3S.9 17.3.9 16s1-2.3 2.3-2.3zm5.8-7C9 7.9 7.9 9 6.7 9S4.4 8 4.4 6.7s1-2.3 2.3-2.3S9 5.4 9 6.7zm16.3 21c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zm2.4-21c0 1.3-1 2.3-2.3 2.3S23 7.9 23 6.7s1-2.3 2.3-2.3 2.4 1 2.4 2.3zM6.7 23C8 23 9 24 9 25.3s-1 2.3-2.3 2.3-2.3-1-2.3-2.3 1-2.3 2.3-2.3z" />
+                </g>
+            </svg>
         </button>
     </div>
 


### PR DESCRIPTION

Replaced the old dark mode toggle with a redesigned button that uses an inline SVG icon for a more modern and intuitive look.

### Changes
- Added a new `<button>` with an embedded SVG sun/moon icon
- Applied semantic attributes: `title`, `aria-label`, and `type="button"`
- Removed or replaced the previous toggle implementation
- Kept styling minimal for easy integration with existing CSS (class: `theme-toggle`)

### Why
The previous toggle was outdated and didn’t fit well visually with the rest of the UI. This new design improves UX by:
- Being more intuitive (icon-based)
- Providing better accessibility
- Looking more polished across light and dark themes


